### PR TITLE
Added thumbnail and fanart properties to Player.GetItem request

### DIFF
--- a/service.mqtt/service.py
+++ b/service.mqtt/service.py
@@ -81,7 +81,7 @@ def publishdetails():
     global lasttitle,lastdetail
     if not player.isPlaying():
         return
-    res=sendrpc("Player.GetItem",{"playerid":activeplayerid,"properties":["title","streamdetails","file"]})
+    res=sendrpc("Player.GetItem",{"playerid":activeplayerid,"properties":["title","streamdetails","file","thumbnail","fanart"]})
     if "result" in res:
         newtitle=res["result"]["item"]["title"]
         newdetail={"kodi_details":res["result"]["item"]}


### PR DESCRIPTION
Added the thumbnail and fanart properties to the Player.GetItem
properities array in the request. This will return a url_encoded object
that can be used with http://kodi_host:port/image/ base url for the
Kodi image cache to retrieve the currently playing thumbnail and/or
fanart.
