### PR TITLE
Fix/hostname

### DIFF
--- a/service.mqtt/resources/settings.xml
+++ b/service.mqtt/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <category label="30001">
-        <setting label="30011" type="ipaddress"   id="mqtthost" default="127.0.0.1"/>
+        <setting label="30011" type="text"   id="mqtthost" default="127.0.0.1"/>
         <setting label="30012" type="number"   id="mqttport" default="1883"/>
         <setting label="30013" type="text" id="mqtttopic" default="kodi/"/>
     </category>


### PR DESCRIPTION
I noticed in the readme and change notes the addition of support for hostname use in the changes for v0.4, including the reference to changing the mqtthost settings type from ipaddress to text. I didn't see a commit for this particular change, so I made the change, tested it and pushing it your way for review.
