### PR TITLE
Add option to disable noisy local logging.

### DIFF
--- a/service.mqtt/resources/language/English/strings.po
+++ b/service.mqtt/resources/language/English/strings.po
@@ -32,6 +32,10 @@ msgctxt "#30013"
 msgid "MQTT Topic Prefix"
 msgstr ""
 
+msgctxt "#30014"
+msgid "MQTT Debug Logging"
+msgstr ""
+
 msgctxt "#30100"
 msgid "Authentication"
 msgstr ""

--- a/service.mqtt/resources/settings.xml
+++ b/service.mqtt/resources/settings.xml
@@ -4,6 +4,7 @@
         <setting label="30011" type="text"   id="mqtthost" default="127.0.0.1"/>
         <setting label="30012" type="number"   id="mqttport" default="1883"/>
         <setting label="30013" type="text" id="mqtttopic" default="kodi/"/>
+        <setting label="30014" type="bool" id="mqttdebug" default="false"/>
     </category>
     <category label="30100">
         <setting label="30101" type="bool"   id="mqttanonymousconnection" default="true" />


### PR DESCRIPTION
A small change to add a 'debug' switch to the configuration settings.

When disabled (disabled by default) stops MQTT Adaptor from writing anything other than the fact it's started running to the kodi.log.
