### PR TITLE
Add TLS options to service and related strings.

### DIFF
--- a/service.mqtt/resources/language/English/strings.po
+++ b/service.mqtt/resources/language/English/strings.po
@@ -47,3 +47,23 @@ msgstr ""
 msgctxt "#30103"
 msgid "Password"
 msgstr ""
+
+msgctxt "#30104"
+msgid "Use TLS connection"
+msgstr ""
+
+msgctxt "#30105"
+msgid "TLS broker CA crt"
+msgstr ""
+
+msgctxt "#30106"
+msgid "Use client certificates"
+msgstr ""
+
+msgctxt "#30107"
+msgid "TLS client certificate"
+msgstr ""
+
+msgctxt "#30108"
+msgid "TLS client key"
+msgstr ""

--- a/service.mqtt/resources/settings.xml
+++ b/service.mqtt/resources/settings.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <category label="30001">
-        <setting label="30011" type="text"   id="mqtthost" default="127.0.0.1"/>
-        <setting label="30012" type="number"   id="mqttport" default="1883"/>
+        <setting label="30011" type="text" id="mqtthost" default="127.0.0.1"/>
+        <setting label="30012" type="number" id="mqttport" default="1883"/>
         <setting label="30013" type="text" id="mqtttopic" default="kodi/"/>
     </category>
     <category label="30100">
-        <setting label="30101" type="bool"   id="mqttanonymousconnection" default="true" />
-        <setting label="30102" type="text"   id="mqttusername" default="" visible="eq(-1,false)" />
-        <setting label="30103" type="text"   id="mqttpassword" option="hidden" default="" visible="eq(-2,false)" />
+        <setting label="30101" type="bool" id="mqttanonymousconnection" default="true" />
+        <setting label="30102" type="text" id="mqttusername" default="" visible="eq(-1,false)" />
+        <setting label="30103" type="text" id="mqttpassword" option="hidden" default="" visible="eq(-2,false)" />
+        <setting label="30104" type="bool" id="mqtttlsconnection" default="false" />
+        <setting label="30105" type="file" id="mqtttlsconnectioncrt" value="" default="" visible="eq(-1,true)" subsetting="true" />
+        <setting label="30106" type="bool" id="mqtttlsclient" default="false" visible="eq(-2,true)" />
+        <setting label="30107" type="file" id="mqtttlsclientcrt" value="" default="" visible="eq(-3,true) + eq(-1,true)" subsetting="true" />
+        <setting label="30108" type="file" id="mqtttlsclientkey" value="" default="" visible="eq(-4,true) + eq(-2,true)" subsetting="true" />
     </category>
 </settings>

--- a/service.mqtt/service.py
+++ b/service.mqtt/service.py
@@ -209,6 +209,13 @@ def startmqtt():
     mqc.on_disconnect=disconnecthandler
     if __addon__.getSetting("mqttanonymousconnection")=='false':
         mqc.username_pw_set(__addon__.getSetting("mqttusername"), __addon__.getSetting("mqttpassword"))
+        xbmc.log("MQTT: Anonymous disabled, connecting as user: %s" % __addon__.getSetting("mqttusername"))
+    if __addon__.getSetting("mqtttlsconnection")=='true' and  __addon__.getSetting("mqtttlsconnectioncrt")!='' and __addon__.getSetting("mqtttlsclient")=='false':
+        mqc.tls_set(__addon__.getSetting("mqtttlsconnectioncrt"))
+        xbmc.log("MQTT: TLS enabled, connecting using CA certificate: %s" % __addon__.getSetting("mqtttlsconnectioncrt"))
+    elif __addon__.getSetting("mqtttlsconnection")=='true' and  __addon__.getSetting("mqtttlsclient")=='true' and __addon__.getSetting("mqtttlsclientcrt")!='' and  __addon__.getSetting("mqtttlsclientkey")!='':    
+        mqc.tls_set(__addon__.getSetting("mqtttlsconnectioncrt"), __addon__.getSetting("mqtttlsclientcrt"), __addon__.getSetting("mqtttlsclientkey"))
+        xbmc.log("MQTT: TLS with client certificates enabled, connecting using certificates CA: %s, client %s and key: %s" % (__addon__.getSetting("mqttusername"), __addon__.getSetting("mqtttlsclientcrt"), __addon__.getSetting("mqtttlsclientkey")))
     topic=__addon__.getSetting("mqtttopic")
     if not topic.endswith("/"):
         topic+="/"


### PR DESCRIPTION
Adding the ability to specify and use the certificates required for TLS.

These are a CA certificate (for the client to validate the broker) and a client certificate and key (for the server to validate the client). They can be switched on independently, although the client certificate also requires a CA certificate be specified to enable TLS in the first place :)

For the settings, I followed the existing UX so hide the file fields until needed, as with the existing authentication user / pass fields.
