### PR TITLE
Fix notify string split

### DIFF
--- a/service.mqtt/service.py
+++ b/service.mqtt/service.py
@@ -139,7 +139,7 @@ def processnotify(data):
     try:
         params=json.loads(data)
     except ValueError:
-        parts=data.split(None,2)
+        parts = data.split(None, 1)
         params={"title":parts[0],"message":parts[1]}
     sendrpc("GUI.ShowNotification",params)
 


### PR DESCRIPTION
Title is the first word of the string, message is the rest

It's minor but it does allow the fallback to display more than just two words.
